### PR TITLE
Feat: Single Video Page with selected video and suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "mockman-js": "^1.1.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-player": "^2.10.0",
+        "react-player": "^2.10.1",
         "react-redux": "^8.0.2",
         "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "mockman-js": "^1.1.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-player": "^2.10.1",
+        "react-player": "^2.10.0",
         "react-redux": "^8.0.2",
         "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "mockman-js": "^1.1.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-player": "^2.10.1",
         "react-redux": "^8.0.2",
         "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^6.3.0",
@@ -10587,6 +10588,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -10863,6 +10869,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -13316,6 +13327,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -13325,6 +13341,21 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-player": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.10.1.tgz",
+      "integrity": "sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==",
+      "dependencies": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "8.0.2",
@@ -23847,6 +23878,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
+    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -24092,6 +24128,11 @@
       "requires": {
         "fs-monkey": "1.0.3"
       }
+    },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -25743,6 +25784,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -25752,6 +25798,18 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-player": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.10.1.tgz",
+      "integrity": "sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==",
+      "requires": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
+      }
     },
     "react-redux": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mockman-js": "^1.1.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-player": "^2.10.1",
     "react-redux": "^8.0.2",
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "mockman-js": "^1.1.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-player": "^2.10.1",
+    "react-player": "^2.10.0",
     "react-redux": "^8.0.2",
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "mockman-js": "^1.1.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-player": "^2.10.0",
+    "react-player": "^2.10.1",
     "react-redux": "^8.0.2",
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.3.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import { AppRoutes } from "routes";
 import { useSelector } from "react-redux";
-import { UpperNavbar, Sidebar, Alerts } from "components";
+import { UpperNavbar, Sidebar, Alerts, ScrollToTop } from "components";
 import styles from "./App.module.css";
 
 function App() {
@@ -14,14 +14,16 @@ function App() {
   };
   return (
     <div className={`${styles.App} ${getClassName(themeProvided)}`}>
-      <UpperNavbar />
-      <div className={`${styles.pageContent}`}>
-        <Sidebar />
-        <div className={`${styles.mainContent}`}>
-          <AppRoutes />
+      <ScrollToTop>
+        <UpperNavbar />
+        <div className={`${styles.pageContent}`}>
+          <Sidebar />
+          <div className={`${styles.mainContent}`}>
+            <AppRoutes />
+          </div>
         </div>
-      </div>
-      <Alerts />
+        <Alerts />
+      </ScrollToTop>
     </div>
   );
 }

--- a/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/ScrollToTop/ScrollToTop.jsx
@@ -1,0 +1,10 @@
+import { useLayoutEffect } from "react";
+import { useLocation } from "react-router-dom";
+const ScrollToTop = ({ children }) => {
+  const { pathname } = useLocation();
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return children;
+};
+export { ScrollToTop };

--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -2,11 +2,18 @@ import React, { useState } from "react";
 import styles from "./VideoCard.module.css";
 import { getVideoImg, viewCountFormatter } from "utilities";
 import { VideoMenuOptions } from "components";
+import { useNavigate } from "react-router-dom";
 const VideoCard = ({ videoDetails }) => {
+  const navigate = useNavigate();
   const { _id, title, viewQuantity, dateOfUpload } = videoDetails;
   const [videoMenuOptionsView, setVideoMenuOptionsView] = useState(false);
   return (
-    <div className={`${styles.video_card_container}`}>
+    <div
+      className={`${styles.video_card_container}`}
+      onClick={() => {
+        navigate(`/explore/${_id}`);
+      }}
+    >
       <img
         src={getVideoImg(_id)}
         alt={title}

--- a/src/components/VideoSuggestionCard/VideoSuggestionCard.jsx
+++ b/src/components/VideoSuggestionCard/VideoSuggestionCard.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { viewCountFormatter, getVideoImg } from "utilities";
+import styles from "./VideoSuggestionCard.module.css";
+const VideoSuggestionCard = ({ videoReceived }) => {
+  const navigate = useNavigate();
+  const { _id, title, viewQuantity, dateOfUpload } = videoReceived;
+  return (
+    <div
+      className={`${styles.video_suggestion_card_container} g-flex-row text-cursor-pointer`}
+      onClick={() => {
+        navigate(`/explore/${_id}`);
+      }}
+    >
+      <img
+        src={getVideoImg(_id)}
+        alt={title}
+        className={`${styles.video_suggestion_img}`}
+      />
+      <div className={`${styles.video_suggestion_card_contents} g-flex-column`}>
+        <div className={`g-flex-row`}>
+          <p className={`${styles.video_suggestion_card_title}`}>{title}</p>
+          <span
+            className={`material-icons g-flex-center ${styles.video_suggestion_card_more_options}`}
+          >
+            more_vert
+          </span>
+        </div>
+        <div
+          className={`g-flex-row g-flex-wrap g-flex-align-center ${styles.video_suggestion_card_more_details}`}
+        >
+          <span>{viewCountFormatter(viewQuantity)} views</span>
+          <span
+            className={`material-icons ${styles.video_suggestion_card_separator}`}
+          >
+            fiber_manual_record
+          </span>
+          <span>{dateOfUpload}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+export { VideoSuggestionCard };

--- a/src/components/VideoSuggestionCard/VideoSuggestionCard.module.css
+++ b/src/components/VideoSuggestionCard/VideoSuggestionCard.module.css
@@ -1,0 +1,53 @@
+.video_suggestion_card_container {
+  gap: 0.5rem;
+}
+
+.video_suggestion_img {
+  width: 40%;
+}
+
+.video_suggestion_card_contents {
+  gap: 0.25rem;
+}
+
+.video_suggestion_card_title {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.video_suggestion_card_more_options {
+  display: flex;
+  visibility: hidden;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--border-rd-circle);
+  aspect-ratio: 1/1;
+}
+
+.video_suggestion_card_container:hover .video_suggestion_card_more_options {
+  visibility: visible;
+}
+
+.video_suggestion_card_more_options:hover {
+  background-color: var(--icon-hover-clr-bg);
+}
+
+.video_suggestion_card_more_details {
+  font-size: 0.875rem;
+  gap: 0.5rem;
+  color: var(--primary-color);
+}
+
+.video_suggestion_card_separator {
+  font-size: 8px;
+}
+
+@media screen and (max-width: 800px) {
+  .video_suggestion_card_more_options {
+    visibility: visible;
+  }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -10,3 +10,4 @@ export { CategoryChips } from "./CategoryChips/CategoryChips";
 export { VideoCard } from "./VideoCard/VideoCard";
 export { VideoMenuOptions } from "./VideoMenuOptions/VideoMenuOptions";
 export { Alerts } from "./Alerts/Alerts";
+export { ScrollToTop } from "./ScrollToTop/ScrollToTop";

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -11,3 +11,4 @@ export { VideoCard } from "./VideoCard/VideoCard";
 export { VideoMenuOptions } from "./VideoMenuOptions/VideoMenuOptions";
 export { Alerts } from "./Alerts/Alerts";
 export { ScrollToTop } from "./ScrollToTop/ScrollToTop";
+export { VideoSuggestionCard } from "./VideoSuggestionCard/VideoSuggestionCard";

--- a/src/hooks/useOnClickOutside.js
+++ b/src/hooks/useOnClickOutside.js
@@ -16,7 +16,7 @@ const useOnClickOutside = (eventHandler, referenceGiven) => {
     return () => {
       document.removeEventListener("touchstart", listenerHandler);
       document.removeEventListener("mousedown", listenerHandler);
-      document.addEventListener("mouseleave", listenerHandler);
+      document.removeEventListener("mouseleave", listenerHandler);
     };
   }, [eventHandler, referenceGiven]);
 };

--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,8 @@
   text-align: center;
 }
 
+/* For video content */
+iframe{
+  width:100%;
+  height:100%;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@
 }
 
 /* For video content */
-iframe{
-  width:100%;
-  height:100%;
+iframe {
+  width: 100%;
+  height: 100%;
 }

--- a/src/pages/SelectedVideoPage/VideoPage.jsx
+++ b/src/pages/SelectedVideoPage/VideoPage.jsx
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import ReactPlayer from "react-player/youtube";
 import styles from "./VideoPage.module.css";
 import { VideoSuggestionCard } from "components";
-import { videoShufflerFunction } from "utilities";
+import { getVideoUrl, videoShufflerFunction } from "utilities";
 
 const VideoPage = () => {
   const { videoId } = useParams();
@@ -44,7 +44,7 @@ const VideoPage = () => {
           <ReactPlayer
             width="100%"
             height="100%"
-            url={`https://youtube.com/watch?v=${videoId}`}
+            url={`${getVideoUrl(videoId)}`}
             controls
           />
         </div>

--- a/src/pages/SelectedVideoPage/VideoPage.jsx
+++ b/src/pages/SelectedVideoPage/VideoPage.jsx
@@ -105,14 +105,20 @@ const VideoPage = () => {
       </div>
 
       <div className={`g-flex-column ${styles.video_suggestions}`}>
-        {videoShufflerFunction(videosList).slice(0,6).map((everyVideo) => {
-          return (
-            <VideoSuggestionCard
-              key={everyVideo._id}
-              videoReceived={everyVideo}
-            />
-          );
-        })}
+        {videoShufflerFunction(videosList)
+          .slice(0, 6)
+          .map((everyVideo) => {
+            if (everyVideo._id !== videoId) {
+              return (
+                <VideoSuggestionCard
+                  key={everyVideo._id}
+                  videoReceived={everyVideo}
+                />
+              );
+            } else {
+              return null;
+            }
+          })}
       </div>
     </div>
   );

--- a/src/pages/SelectedVideoPage/VideoPage.jsx
+++ b/src/pages/SelectedVideoPage/VideoPage.jsx
@@ -3,6 +3,8 @@ import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import ReactPlayer from "react-player/youtube";
 import styles from "./VideoPage.module.css";
+import { VideoSuggestionCard } from "components";
+import { videoShufflerFunction } from "utilities";
 
 const VideoPage = () => {
   const { videoId } = useParams();
@@ -40,10 +42,10 @@ const VideoPage = () => {
       >
         <div className={`${styles.selected_video_player}`}>
           <ReactPlayer
-            height="100%"
             width="100%"
-            controls
+            height="100%"
             url={`https://youtube.com/watch?v=${videoId}`}
+            controls
           />
         </div>
         <div className={`${styles.selected_video_contents} g-flex-column`}>
@@ -102,7 +104,16 @@ const VideoPage = () => {
         </div>
       </div>
 
-      <div>{/* More videos for suggestions */}</div>
+      <div className={`g-flex-column ${styles.video_suggestions}`}>
+        {videoShufflerFunction(videosList).slice(0,6).map((everyVideo) => {
+          return (
+            <VideoSuggestionCard
+              key={everyVideo._id}
+              videoReceived={everyVideo}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/src/pages/SelectedVideoPage/VideoPage.jsx
+++ b/src/pages/SelectedVideoPage/VideoPage.jsx
@@ -1,0 +1,109 @@
+import React, { useState, useRef, useEffect } from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
+import ReactPlayer from "react-player/youtube";
+import styles from "./VideoPage.module.css";
+
+const VideoPage = () => {
+  const { videoId } = useParams();
+  const { videosList } = useSelector((storeReceived) => storeReceived.videos);
+  const { sidebarView } = useSelector((storeReceived) => storeReceived.sidebar);
+  const videoSelected = videosList.find(
+    (everyVideo) => everyVideo._id === videoId
+  );
+  const { title, dateOfUpload, viewQuantity, description } = videoSelected;
+  const videoPageRef = useRef();
+  const [videoPageDimensions, setVideoPageDimensions] = useState();
+  const getCurrentPageDimensions = () => {
+    const widthReceived = videoPageRef.current.clientWidth;
+    setVideoPageDimensions(widthReceived);
+  };
+  //   For receiving the page width whenever the window is resized and setting it
+  useEffect(() => {
+    getCurrentPageDimensions();
+  }, [videosList, sidebarView]);
+  useEffect(() => {
+    window.addEventListener("resize", getCurrentPageDimensions);
+  }, []);
+  return (
+    <div
+      ref={videoPageRef}
+      className={`${styles.video_page_container}`}
+      style={{ flexDirection: videoPageDimensions < 1165 ? "column" : "row" }}
+    >
+      {/* Main selected video content would be displayed here */}
+      <div
+        className={`${styles.selected_video_section} g-flex-column`}
+        style={{
+          alignSelf: videoPageDimensions < 1165 && "stretch",
+        }}
+      >
+        <div className={`${styles.selected_video_player}`}>
+          <ReactPlayer
+            height="100%"
+            width="100%"
+            controls
+            url={`https://youtube.com/watch?v=${videoId}`}
+          />
+        </div>
+        <div className={`${styles.selected_video_contents} g-flex-column`}>
+          <h1 className={`${styles.selected_video_contents_title}`}>{title}</h1>
+          <div className={`g-flex-row g-flex-align-center g-flex-wrap`}>
+            <div
+              className={`g-flex-row g-flex-align-center ${styles.selected_videos_sub_content}`}
+            >
+              <span>{viewQuantity} views</span>
+              <span
+                className={`material-icons ${styles.selected_video_contents_separator}`}
+              >
+                fiber_manual_record
+              </span>
+              <span>{dateOfUpload}</span>
+            </div>
+            <div
+              className={`g-flex-row g-flex-center ${styles.selected_video_actions}`}
+            >
+              <button
+                className={`${styles.selected_video_action_btn} g-flex-row g-flex-center text-cursor-pointer`}
+              >
+                <span
+                  className={`material-icons-outlined ${styles.selected_video_action_icon}`}
+                  title="Like this video"
+                >
+                  thumb_up
+                </span>
+              </button>
+              <button
+                className={`${styles.selected_video_action_btn} g-flex-row g-flex-center text-cursor-pointer`}
+              >
+                <span
+                  className={`material-icons-outlined ${styles.selected_video_action_icon}`}
+                  title="Watch this video later"
+                >
+                  watch_later
+                </span>
+              </button>
+              <button
+                className={`${styles.selected_video_action_btn} g-flex-row g-flex-center text-cursor-pointer`}
+              >
+                <span
+                  className={`material-icons-outlined ${styles.selected_video_action_icon}`}
+                  title="Add this video to a playlist"
+                >
+                  playlist_add
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div className={`${styles.selected_video_line}`}></div>
+        <div className={`${styles.selected_video_description}`}>
+          {description}
+        </div>
+      </div>
+
+      <div>{/* More videos for suggestions */}</div>
+    </div>
+  );
+};
+export { VideoPage };

--- a/src/pages/SelectedVideoPage/VideoPage.module.css
+++ b/src/pages/SelectedVideoPage/VideoPage.module.css
@@ -65,6 +65,11 @@
   width: 50rem;
 }
 
+.video_suggestions {
+  flex-basis: 30%;
+  gap: 1rem;
+}
+
 @media only screen and (max-width: 1250px) {
   .video_page_container {
     flex-direction: column;

--- a/src/pages/SelectedVideoPage/VideoPage.module.css
+++ b/src/pages/SelectedVideoPage/VideoPage.module.css
@@ -1,0 +1,80 @@
+.video_page_container {
+  margin: 1rem;
+  display: flex;
+  gap: 2rem;
+}
+
+.selected_video_section {
+  gap: 1rem;
+  flex-grow: 1;
+  align-self: flex-start;
+}
+
+.selected_video_player {
+  aspect-ratio: 16/9;
+}
+
+.selected_video_contents {
+  gap: 0.5rem;
+}
+
+.selected_video_contents_title {
+  font-size: 1.25rem;
+  font-weight: 400;
+  font-family: "Catamaran", sans-serif;
+}
+
+.selected_videos_sub_content {
+  font-size: 0.875rem;
+  color: var(--text-clr-choice);
+  gap: 0.5rem;
+}
+
+.selected_video_contents_separator {
+  font-size: 8px;
+}
+
+.selected_video_actions {
+  margin-left: auto;
+}
+
+.selected_video_action_btn {
+  aspect-ratio: 1/1;
+  padding: 0.75rem;
+  border-radius: var(--border-rd-circle);
+  border: transparent;
+  outline: transparent;
+  background: transparent;
+  color: inherit;
+}
+
+.selected_video_action_btn:hover {
+  background-color: var(--icon-hover-clr-bg);
+}
+
+.selected_video_action_icon {
+  font-size: 1.75rem;
+}
+
+.selected_video_line {
+  height: 1px;
+  background-color: var(--primary-color);
+}
+
+.selected_video_description {
+  width: 50rem;
+}
+
+@media only screen and (max-width: 1250px) {
+  .video_page_container {
+    flex-direction: column;
+  }
+
+  .selected_video_section {
+    align-self: stretch;
+  }
+
+  .selected_video_description {
+    width: 100%;
+  }
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,3 +3,4 @@ export { Mockbee } from "./Mockbee/Mockbee";
 export { Homepage } from "./Homepage/Homepage";
 export { ExplorePage } from "./ExplorePage/ExplorePage";
 export { Login, Signup } from "./Authentication";
+export { VideoPage } from "./SelectedVideoPage/VideoPage";

--- a/src/reduxFiles/reducers/videos/videosSlice.js
+++ b/src/reduxFiles/reducers/videos/videosSlice.js
@@ -2,7 +2,7 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { receiveAllVideos } from "services";
 const initialState = {
   status: null,
-  videosList: [],
+  videosList: JSON.parse(localStorage.getItem("videosList"))??[],
 };
 const getVideosService = async () => {
   try {
@@ -29,6 +29,7 @@ const videosSlice = createSlice({
     [getVideos.fulfilled]: (state, action) => {
       state.status = "fulfilled";
       state.videosList = action.payload;
+      localStorage.setItem("videosList",JSON.stringify(action.payload))
     },
     [getVideos.failed]: (state, action) => {
       state.status = "failed";

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -7,6 +7,7 @@ import {
   ExplorePage,
   Login,
   Signup,
+  VideoPage,
 } from "pages";
 import { ProtectedRoutes } from "./ProtectedRoutes";
 
@@ -15,6 +16,7 @@ const AppRoutes = () => {
     <Routes>
       <Route path="/" element={<Homepage />} />
       <Route path="/explore" element={<ExplorePage />} />
+      <Route path="/explore/:videoId" element={<VideoPage />} />
       <Route path="/mockman" element={<APITester />} />
       <Route path="/mockbee" element={<Mockbee />} />
       <Route path="/login" element={<Login />} />

--- a/src/utilities/VideoDetailGenerators/getVideoUrl.js
+++ b/src/utilities/VideoDetailGenerators/getVideoUrl.js
@@ -1,0 +1,4 @@
+const getVideoUrl = (videoIdGiven) => {
+  return `https://youtube.com/watch?v=${videoIdGiven}`;
+};
+export { getVideoUrl };

--- a/src/utilities/VideoDetailGenerators/index.js
+++ b/src/utilities/VideoDetailGenerators/index.js
@@ -1,2 +1,3 @@
 export { viewCountFormatter } from "./viewCountFormatter";
 export { getVideoImg } from "./getVideoImage";
+export { getVideoUrl } from "./getVideoUrl";


### PR DESCRIPTION
In this Pull request reviewer would find the codebase required to develop a route that the user will be redirected to whenever he clicks on a particular video in the explore section. 
1) After getting redirected to the Selected Video Page he would be able to view the selected video that will be played through a medium and some more video suggestions on the right. There are some actions if the user wants to keep any of the videos in private collections like liked,watch later (these features haven't been added yet)
2) Have added a component that enables the user to scroll to the top whenver the user changes routes.

Here is the live preview link for the same: https://mi-stream-git-single-video-page-dev-enforced.vercel.app/explore