### PR TITLE
Feat history with UI

### DIFF
--- a/src/pages/HistoryPage/HistoryPage.jsx
+++ b/src/pages/HistoryPage/HistoryPage.jsx
@@ -1,0 +1,86 @@
+import React, { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { EmptyPage } from "pages";
+import { CollectionCard } from "components";
+import { emptyHistoryImage } from "constants";
+import { receiveAllHistoryVideos, clearEntireHistory } from "reduxFiles";
+import styles from "./HistoryPage.module.css";
+import { getVideoImg } from "utilities";
+import { useAlerts } from "hooks";
+
+
+const HistoryPage = () => {
+  const dispatch = useDispatch();
+  const { status, historyVideosList } = useSelector(
+    (storeReceived) => storeReceived.historyStore
+  );
+  const { encodedTokenReceived } = useSelector(
+    (storeReceived) => storeReceived.authenticationStore
+  );
+  const {showAlerts}=useAlerts();
+  useEffect(() => {
+    dispatch(receiveAllHistoryVideos(encodedTokenReceived));
+  }, [dispatch, encodedTokenReceived]);
+  return (
+    <>
+      {status === "loading" ? (
+        <h1>Fetching the videos of History....</h1>
+      ) : (
+        <>
+          {historyVideosList.length === 0 ? (
+            <EmptyPage
+              messageToBeDisplayed={"You have not watched any videos yet"}
+              imageToBeDisplayed={emptyHistoryImage}
+            />
+          ) : (
+            <div className={`${styles.history_page}`}>
+              <div
+                className={`${styles.history_page_title_card_container} g-flex-column`}
+              >
+                <div className={`${styles.history_page_title_card}`}>
+                  <img
+                    className={`${styles.history_page_title_card_img}`}
+                    src={getVideoImg(
+                      historyVideosList[historyVideosList.length - 1]._id
+                    )}
+                    alt="Watch Later Videos"
+                  />
+                  <div
+                    className={`g-flex-row g-flex-center fw-500 p-4 fs-1-25 ${styles.history_page_title_card_content}`}
+                  >
+                    <span className="material-icons">history</span>
+                    <span>HISTORY</span>
+                  </div>
+                </div>
+                <button
+                  className={`${styles.history_page_clear_all}`}
+                  onClick={() => {
+                    dispatch(clearEntireHistory(encodedTokenReceived));
+                    showAlerts("success","Cleared the whole history")
+                  }}
+                >
+                  Clear All
+                </button>
+              </div>
+
+              <div
+                className={`g-flex-column ${styles.history_page_video_list}`}
+              >
+                {/* Liked videos list will come here */}
+                {historyVideosList.map((everyVideo) => {
+                  return (
+                    <CollectionCard
+                      key={everyVideo._id}
+                      videoDetails={everyVideo}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+export { HistoryPage };

--- a/src/pages/HistoryPage/HistoryPage.module.css
+++ b/src/pages/HistoryPage/HistoryPage.module.css
@@ -1,0 +1,51 @@
+.history_page {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem;
+}
+.history_page_title_card_container {
+  align-self: flex-start;
+  min-width: 25rem;
+  flex-basis: 30%;
+  gap: 1rem;
+}
+.history_page_title_card {
+  position: relative;
+}
+.history_page_title_card_img{
+    width: 100%;
+}
+.history_page_title_card_content{
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    gap: 0.5rem;
+    background-color: var(--text-clr-choice);
+    color:var(--bg-clr-choice);
+}
+.history_page_video_list{
+    flex-grow: 1;
+}
+
+.history_page_clear_all{
+    border: transparent;
+    outline: transparent;
+    background: transparent;
+    font-weight: 700;
+    font-family: 'Catamaran',sans-serif;
+    padding: 0.75rem 1rem;
+    border-radius: var(--border-rd-sm);
+    align-self: flex-start;
+    background-color: var(--primary-color);
+    color: var(--text-clr-choice);
+    cursor: pointer;
+}
+@media screen and (max-width: 1020px) {
+  .history_page {
+    flex-direction: column;
+  }
+  .history_page_title_card_container {
+    flex-basis: 100%;
+    min-width: unset;
+  }
+}

--- a/src/pages/SelectedVideoPage/VideoPage.jsx
+++ b/src/pages/SelectedVideoPage/VideoPage.jsx
@@ -9,6 +9,8 @@ import {
   addNewVideoToWatchLater,
   removeExistingVideoFromLikes,
   removeExistingVideoFromWatchLater,
+  addNewVideoToHistory,
+  removeExistingVideoFromHistory,
 } from "reduxFiles";
 import { useAlerts } from "hooks";
 import styles from "./VideoPage.module.css";
@@ -31,6 +33,9 @@ const VideoPage = () => {
   const { watchLaterVideosList, status: watchLaterStatus } = useSelector(
     (storeReceived) => storeReceived.watchLaterStore
   );
+  const { historyVideosList } = useSelector(
+    (storeReceived) => storeReceived.historyStore
+  );
   const videoSelected = videosList.find(
     (everyVideo) => everyVideo._id === videoId
   );
@@ -48,6 +53,26 @@ const VideoPage = () => {
   const checkVideoPresentInWatchLater = (selectedVideoDetails) => {
     return watchLaterVideosList.some(
       (everyVideo) => everyVideo._id === selectedVideoDetails._id
+    );
+  };
+  const checkVideoPresentInHistory = (selectedVideoDetails) =>
+    historyVideosList.some(
+      (everyVideo) => everyVideo._id === selectedVideoDetails._id
+    );
+  const addNewVideoToHistoryEvent = (selectedVideoDetails) => {
+    if (checkVideoPresentInHistory(selectedVideoDetails)) {
+      dispatch(
+        removeExistingVideoFromHistory({
+          videoDetailsGiven: selectedVideoDetails,
+          tokenProvided: encodedTokenReceived,
+        })
+      );
+    }
+    dispatch(
+      addNewVideoToHistory({
+        videoDetailsGiven: selectedVideoDetails,
+        tokenProvided: encodedTokenReceived,
+      })
     );
   };
   const addVideoToLikeEvent = (selectedVideoDetails) => {
@@ -156,6 +181,10 @@ const VideoPage = () => {
             height="100%"
             url={`${getVideoUrl(videoId)}`}
             controls
+            playing
+            onStart={() => {
+              addNewVideoToHistoryEvent(videoSelected);
+            }}
           />
         </div>
         <div className={`${styles.selected_video_contents} g-flex-column`}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,3 +7,4 @@ export { VideoPage } from "./SelectedVideoPage/VideoPage";
 export { EmptyPage } from "./EmptyPage/EmptyPage";
 export { LikesPage } from "./LikesPage/LikesPage";
 export { WatchLaterPage } from "./WatchLaterPage/WatchLaterPage";
+export { HistoryPage } from "./HistoryPage/HistoryPage";

--- a/src/reduxFiles/reducers/history/historySlice.js
+++ b/src/reduxFiles/reducers/history/historySlice.js
@@ -1,0 +1,161 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  addVideoToHistoryService,
+  removeVideoFromHistoryService,
+  receiveAllHistoryVideosService,
+  clearEntireHistoryService,
+} from "services";
+
+const initialState = {
+  status: null,
+  historyVideosList: [],
+  error: null,
+};
+
+const receiveAllHistoryVideosHandler = async (
+  tokenProvided,
+  { rejectWithValue }
+) => {
+  try {
+    const {
+      data: { history: historyVideosResponse },
+    } = await receiveAllHistoryVideosService(tokenProvided);
+    return historyVideosResponse;
+  } catch (receiveAllHistoryVideosError) {
+    console.error(
+      "AN ERROR OCCURED WHILE RECEIVING VIDEOS IN HISTORY THROUGH REDUX IMPLEMENTATION"
+    );
+    return rejectWithValue("Error in receiving items from history");
+  }
+};
+
+const addNewVideoToHistoryHandler = async (
+  { videoDetailsGiven, tokenProvided },
+  { rejectWithValue }
+) => {
+  try {
+    const {
+      data: { history: historyVideosResponse },
+    } = await addVideoToHistoryService(videoDetailsGiven, tokenProvided);
+    return historyVideosResponse;
+  } catch (addNewVideoToHistoryError) {
+    console.error(
+      "AN ERROR OCCURED WHILE ADDING VIDEOS IN HISTORY THROUGH REDUX IMPLEMENTATION"
+    );
+    return rejectWithValue("Error in adding video to history");
+  }
+};
+
+const removeExistingVideoFromHistoryHandler = async (
+  { videoDetailsGiven, tokenProvided },
+  { rejectWithValue }
+) => {
+  try {
+    const {
+      data: { history: historyVideosResponse },
+    } = await removeVideoFromHistoryService(videoDetailsGiven, tokenProvided);
+    return historyVideosResponse;
+  } catch (removeExistingVideoFromHistoryError) {
+    console.error(
+      "AN ERROR OCCURED WHILE REMOVING A VIDEOS FROM HISTORY THROUGH REDUX IMPLEMENTATION"
+    );
+    return rejectWithValue("Error occured in removing a video from history");
+  }
+};
+
+const clearEntireHistoryHandler = async (
+  tokenProvided,
+  { rejectWithValue }
+) => {
+  try {
+    const {
+      data: { history: historyVideosResponse },
+    } = await clearEntireHistoryService(tokenProvided);
+    return historyVideosResponse;
+  } catch (clearEntireHistoryError) {
+    console.error(
+      "An error occured while clearing all videos of history through Redux implementation"
+    );
+    return rejectWithValue("AN ERROR OCCURED WHILE CLEARING HISTORY");
+  }
+};
+
+const receiveAllHistoryVideos = createAsyncThunk(
+  "userHistory/recieveAllHistoryVideos",
+  receiveAllHistoryVideosHandler
+);
+
+const addNewVideoToHistory = createAsyncThunk(
+  "userHistory/addNewVideoToHistory",
+  addNewVideoToHistoryHandler
+);
+
+const removeExistingVideoFromHistory = createAsyncThunk(
+  "userHistory/removeExistingVideoFromHistory",
+  removeExistingVideoFromHistoryHandler
+);
+
+const clearEntireHistory = createAsyncThunk(
+  "userHistory/clearEntireHistory",
+  clearEntireHistoryHandler
+);
+
+const historySlice = createSlice({
+  name: "userHistory",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(receiveAllHistoryVideos.pending, (state, action) => {
+        state.status = "pending";
+      })
+      .addCase(receiveAllHistoryVideos.fulfilled, (state, action) => {
+        state.status = "fulfilled";
+        state.historyVideosList = action.payload;
+      })
+      .addCase(receiveAllHistoryVideos.rejected, (state, action) => {
+        state.status = "rejected";
+        state.error = action.payload;
+      })
+      .addCase(addNewVideoToHistory.pending, (state, action) => {
+        state.status = "pending";
+      })
+      .addCase(addNewVideoToHistory.fulfilled, (state, action) => {
+        state.status = "fulfilled";
+        state.historyVideosList = action.payload;
+      })
+      .addCase(addNewVideoToHistory.rejected, (state, action) => {
+        state.status = "rejected";
+        state.error = action.payload;
+      })
+      .addCase(removeExistingVideoFromHistory.pending, (state, action) => {
+        state.status = "pending";
+      })
+      .addCase(removeExistingVideoFromHistory.fulfilled, (state, action) => {
+        state.status = "fulfilled";
+        state.historyVideosList = action.payload;
+      })
+      .addCase(removeExistingVideoFromHistory.rejected, (state, action) => {
+        state.status = "rejected";
+        state.error = action.payload;
+      })
+      .addCase(clearEntireHistory.pending, (state, action) => {
+        state.status = "pending";
+      })
+      .addCase(clearEntireHistory.fulfilled, (state, action) => {
+        state.status = "fulfilled";
+        state.historyVideosList = action.payload;
+      })
+      .addCase(clearEntireHistory.rejected, (state, action) => {
+        state.status = "rejected";
+        state.error = action.payload;
+      });
+  },
+});
+export {
+  receiveAllHistoryVideos,
+  addNewVideoToHistory,
+  clearEntireHistory,
+  removeExistingVideoFromHistory,
+};
+export default historySlice.reducer;

--- a/src/reduxFiles/reducers/index.js
+++ b/src/reduxFiles/reducers/index.js
@@ -20,3 +20,9 @@ export {
   addNewVideoToWatchLater,
   removeExistingVideoFromWatchLater,
 } from "./watch-later/watchLaterSlice";
+export {
+  receiveAllHistoryVideos,
+  addNewVideoToHistory,
+  clearEntireHistory,
+  removeExistingVideoFromHistory,
+} from "./history/historySlice";

--- a/src/reduxFiles/store/store.js
+++ b/src/reduxFiles/store/store.js
@@ -6,6 +6,7 @@ import categoriesReducer from "../reducers/categories/categoriesSlice";
 import authenticationReducer from "../reducers/authentication/authenticationSlice";
 import likesReducer from "../reducers/likes/likesSlice";
 import watchLaterReducer from "../reducers/watch-later/watchLaterSlice";
+import historyReducer from "../reducers/history/historySlice";
 const storeGiven = configureStore({
   reducer: {
     theme: themeReducer,
@@ -15,6 +16,7 @@ const storeGiven = configureStore({
     authenticationStore: authenticationReducer,
     likesStore: likesReducer,
     watchLaterStore: watchLaterReducer,
+    historyStore: historyReducer,
   },
 });
 export { storeGiven };

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -10,6 +10,7 @@ import {
   VideoPage,
   LikesPage,
   WatchLaterPage,
+  HistoryPage,
 } from "pages";
 import { ProtectedRoutes } from "./ProtectedRoutes";
 
@@ -30,6 +31,10 @@ const AppRoutes = () => {
       <Route
         path="/watchlater"
         element={<ProtectedRoutes protectedChildren={<WatchLaterPage />} />}
+      />
+      <Route
+        path="/history"
+        element={<ProtectedRoutes protectedChildren={<HistoryPage />} />}
       />
     </Routes>
   );

--- a/src/services/HistoryServices/addVideoToHistoryService.js
+++ b/src/services/HistoryServices/addVideoToHistoryService.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+const addVideoToHistoryService = (videoDetailsGven, tokenProvided) =>
+  axios.post(
+    "/api/user/history",
+    {
+      video: { ...videoDetailsGven },
+    },
+    {
+      headers: {
+        authorization: tokenProvided,
+      },
+    }
+  );
+export { addVideoToHistoryService };

--- a/src/services/HistoryServices/clearEntireHistoryService.js
+++ b/src/services/HistoryServices/clearEntireHistoryService.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+const clearEntireHistoryService = (tokenProvided) =>
+  axios.delete("/api/user/history/all", {
+    headers: {
+      authorization: tokenProvided,
+    },
+  });
+export { clearEntireHistoryService };

--- a/src/services/HistoryServices/index.js
+++ b/src/services/HistoryServices/index.js
@@ -1,0 +1,4 @@
+export { receiveAllHistoryVideosService } from "./receiveAllHistoryVideosService";
+export { addVideoToHistoryService } from "./addVideoToHistoryService";
+export { removeVideoFromHistoryService } from "./removeVideoFromHistoryService";
+export { clearEntireHistoryService } from "./clearEntireHistoryService";

--- a/src/services/HistoryServices/receiveAllHistoryVideosService.js
+++ b/src/services/HistoryServices/receiveAllHistoryVideosService.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+const receiveAllHistoryVideosService = (tokenProvided) =>
+  axios.get("/api/user/history", {
+    headers: {
+      authorization: tokenProvided,
+    },
+  });
+export { receiveAllHistoryVideosService };

--- a/src/services/HistoryServices/removeVideoFromHistoryService.js
+++ b/src/services/HistoryServices/removeVideoFromHistoryService.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+const removeVideoFromHistoryService = (videoDetailsGiven, tokenProvided) =>
+  axios.delete(`/api/user/history/${videoDetailsGiven._id}`, {
+    headers: {
+      authorization: tokenProvided,
+    },
+  });
+export { removeVideoFromHistoryService };

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -3,3 +3,4 @@ export * from "./VideoServices";
 export * from "./AuthenticationServices";
 export * from "./LikeVideoServices";
 export * from "./WatchLaterVideoServices";
+export * from "./HistoryServices";


### PR DESCRIPTION
Live link to explore feature: https://mi-stream-git-feat-history-with-ui-dev-enforced.vercel.app/
In this Pull request the reviewer would be able to see the functionality of a video getting added to history when the reviewer has started watching the video when logged in to the application. After watching few videos, the reviewer can go to the history navlink on sidebar to get to the history page with the list of videos that have been watched 

Suppose if you have watched the same video twice then that video would be shown at the bottom of the list as the most latest watched video lies at the bottom. Along with that on the History route itself,reviewer has the option to either delete a particular video or clear the whole history while going through different videos.